### PR TITLE
Don't import the big chunk of material-ui 

### DIFF
--- a/src/components/AppBar/index.js
+++ b/src/components/AppBar/index.js
@@ -3,7 +3,7 @@
  */
 
 import React                   from 'react';
-import { AppBar as MuiAppBar } from 'material-ui';
+import MuiAppBar               from 'material-ui/AppBar';
 
 /* component styles */
 import { styles } from './styles.scss';

--- a/src/components/TextField/index.js
+++ b/src/components/TextField/index.js
@@ -3,7 +3,7 @@
  */
 
 import React                              from 'react';
-import { TextField as MaterialTextField } from 'material-ui';
+import MaterialTextField                  from 'material-ui/TextField';
 import PropTypes                          from 'prop-types';
 
 

--- a/src/containers/LeftNavBar/index.js
+++ b/src/containers/LeftNavBar/index.js
@@ -1,7 +1,9 @@
 import React, { Component }   from 'react';
 import { connect }            from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Drawer, AppBar, Divider } from 'material-ui';
+import AppBar from 'material-ui/AppBar';
+import Drawer from 'material-ui/Drawer';
+import Divider from 'material-ui/Divider';
 import * as _ from 'lodash';
 import Menu from 'material-ui/Menu';
 import MenuItem from 'material-ui/MenuItem';


### PR DESCRIPTION
Tree shaking may fail if we import material-ui directly. I didn't see much size different in this app though.

It's 898KB now
<img width="475" alt="screen shot 2018-02-28 at 14 44 38" src="https://user-images.githubusercontent.com/341555/36775770-f3c443c2-1c95-11e8-967d-ab008b71c17d.png">
